### PR TITLE
bump mdanter/ecc to v0.5.0 for php 7.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=7.1",
-    "mdanter/ecc": "v0.4.2",
+    "mdanter/ecc": "v0.5.0",
     "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {


### PR DESCRIPTION
**mdanter/ecc v0.4.x** use as dependency **fgrosse/phpasn1** v1.5 what use "Object" as class name. **Object is reserved word in php 7.2.** 
**mdanter/ecc v0.5.x** use as dependency **fgrosse/phpasn1** v2.0 where is "Object" renamed to ASNObject. see here: https://github.com/fgrosse/PHPASN1/commit/889ef57df5b9219994c85e675de092012a29e4a2