### PR TITLE
Fix compatibility with php 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require": {
     "php": ">=7.1",
-    "mdanter/ecc": "v0.4.2",
+    "mdanter/ecc": "v0.5.0",
     "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {


### PR DESCRIPTION
mdanter/ecc v0.4.x use as dependency fgrosse/phpasn1 v1.5 what use "Object" as class name. Object is reserved word in php 7.2.
mdanter/ecc v0.5.x use as dependency fgrosse/phpasn1 v2.0 where is "Object" renamed to ASNObject. see here: fgrosse/PHPASN1@889ef57